### PR TITLE
Fix of InvalidOperationException in VS when Ctrl+. is pressed.

### DIFF
--- a/src/Vsix/Analyzers/Base/CommonSuggestedActionsSource.cs
+++ b/src/Vsix/Analyzers/Base/CommonSuggestedActionsSource.cs
@@ -31,10 +31,10 @@ namespace Disasmo
                     new ObjectLayoutSuggestedAction(this),
                 };
         }
-        
+
         public event EventHandler<EventArgs> SuggestedActionsChanged;
 
-        public void Dispose() {}
+        public void Dispose() { }
 
         public IEnumerable<SuggestedActionSet> GetSuggestedActions(
             ISuggestedActionCategorySet requestedActionCategories, SnapshotSpan range,
@@ -48,7 +48,7 @@ namespace Disasmo
                     {
                         a.SnapshotSpan = range;
                         a.CaretPosition = GetCaretPosition();
-                        return new SuggestedActionSet(a.GetType().Name, new[] {a});
+                        return new SuggestedActionSet(PredefinedSuggestedActionCategoryNames.Any, new[] { a });
                     }).ToArray();
             }
             catch


### PR DESCRIPTION
Solves issue #9.

Had debug VS with dnSpy - I found out that unknown category names were used from Disasmo. With advise from https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.language.intellisense.suggestedactionset.categoryname?view=visualstudiosdk-2019 I was able to fix it.
Still don't understand how it is possible it worked for others.