### PR TITLE
Properties/indexers support. Better suggestion display texts.

### DIFF
--- a/Disasmo.Tests/DisasmMethodOrClassActionTests.cs
+++ b/Disasmo.Tests/DisasmMethodOrClassActionTests.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.CodeAnalysis;
+
+namespace Disasmo.Tests
+{
+    [TestClass]
+    public class DisasmMethodOrClassActionTests
+    {
+        [TestMethod]
+        public void TestDisasmoSuggestedActionSymbol()
+        {
+            var semanticModel = RoslynHelper.GetSemanticModelForSourceCode(ISymbolExtensionsTests.SourceCode);
+
+            Check("MyClass");
+            Check("MyStruct");
+            Check("MyMethod");
+            Check("MyProperty");
+            Check("get { return p_");
+            Check("set { p_");
+            Check("this[");
+            Check("get { return i_");
+            Check("set { i_");
+            Check("set { i_");
+
+            Check("p_field", isInteresting: false);
+            Check("i_field", isInteresting: false);
+            Check("MyNamespace", isInteresting: false);
+            Check("void", isInteresting: false);
+            Check("return", isInteresting: false);
+            Check("struct", isInteresting: false);
+            Check("=", isInteresting: false);
+            Check("value", isInteresting: false);
+
+            async void Check(string uniqueIdentifier, bool isInteresting = true)
+            {
+                int tokenPosition = ISymbolExtensionsTests.SourceCode.IndexOf(uniqueIdentifier);
+                var actionSymbol = await DisasmMethodOrClassAction.GetSymbolAsync(semanticModel, tokenPosition, default);
+                var expectedSymbol = isInteresting ? RoslynHelper.GetSymbolAtPosition(semanticModel, tokenPosition) : null;
+                Assert.IsTrue(SymbolEqualityComparer.Default.Equals(expectedSymbol, actionSymbol));
+            }
+        }
+    }
+}

--- a/Disasmo.Tests/Disasmo.Tests.csproj
+++ b/Disasmo.Tests/Disasmo.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>library</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="16.4.280" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="16.4.280" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="3.4.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="16.4.280" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Vsix\Disasmo.Vsix.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Disasmo.Tests/ISymbolExtensionsTests.cs
+++ b/Disasmo.Tests/ISymbolExtensionsTests.cs
@@ -22,6 +22,9 @@ namespace MyNamespace
             set { p_field = value; }
         }
 
+        int MyPropertyGetterOnly => p_field;
+        int MyPropertySetterOnly { set { p_field = value; } }
+
         int this[int i]
         {
             get { return i_field; }
@@ -61,6 +64,8 @@ namespace MyNamespace
             Check("MyClass::get_MyProperty MyClass::set_MyProperty", "MyProperty");
             Check("MyClass::get_MyProperty", "get { return p_");
             Check("MyClass::set_MyProperty", "set { p_");
+            Check("MyClass::get_MyPropertyGetterOnly", "MyPropertyGetterOnly");
+            Check("MyClass::set_MyPropertySetterOnly", "MyPropertySetterOnly");
             Check("MyClass::get_Item MyClass::set_Item", "this[");
             Check("MyClass::get_Item", "get { return i_");
             Check("MyClass::set_Item", "set { i_");

--- a/Disasmo.Tests/ISymbolExtensionsTests.cs
+++ b/Disasmo.Tests/ISymbolExtensionsTests.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Disasmo.Analyzers;
+
+namespace Disasmo.Tests
+{
+    [TestClass]
+    public class ISymbolExtensionsTests
+    {
+        internal const string SourceCode = @"
+namespace MyNamespace
+{
+    class MyClass
+    {
+        int p_field;
+        int i_field;
+
+        void MyMethod() { }
+
+        int MyProperty
+        {
+            get { return p_field; }
+            set { p_field = value; }
+        }
+
+        int this[int i]
+        {
+            get { return i_field; }
+            set { i_field = value; }
+        }
+    }
+    struct MyStruct { }
+}
+";
+
+        [TestMethod]
+        public void GetDisasmSuggestedActionDisplayTextTest()
+        {
+            Check("Disasm 'MyClass' class", "MyClass");
+            Check("Disasm 'MyStruct' struct", "MyStruct");
+            Check("Disasm 'MyMethod' method", "MyMethod");
+            Check("Disasm 'MyProperty' property", "MyProperty");
+            Check("Disasm 'MyProperty' property getter", "get { return p_");
+            Check("Disasm 'MyProperty' property setter", "set { p_");
+            Check("Disasm 'this[]' indexer", "this[");
+            Check("Disasm 'this[]' indexer getter", "get { return i_");
+            Check("Disasm 'this[]' indexer setter", "set { i_");
+
+            void Check(string expectedText, string uniqueIdentifier)
+            {
+                var symbol = RoslynHelper.GetSymbolByUniqueIdentifier(SourceCode, uniqueIdentifier);
+                Assert.AreEqual(expectedText, symbol.GetDisasmSuggestedActionDisplayText());
+            }
+        }
+
+        [TestMethod]
+        public void GetJitDisasmTargetTest()
+        {
+            Check("MyClass::*", "MyClass");
+            Check("MyStruct::*", "MyStruct");
+            Check("MyClass::MyMethod", "MyMethod");
+            Check("MyClass::get_MyProperty MyClass::set_MyProperty", "MyProperty");
+            Check("MyClass::get_MyProperty", "get { return p_");
+            Check("MyClass::set_MyProperty", "set { p_");
+            Check("MyClass::get_Item MyClass::set_Item", "this[");
+            Check("MyClass::get_Item", "get { return i_");
+            Check("MyClass::set_Item", "set { i_");
+
+            void Check(string expectedText, string uniqueIdentifier)
+            {
+                var symbol = RoslynHelper.GetSymbolByUniqueIdentifier(SourceCode, uniqueIdentifier);
+                Assert.AreEqual(expectedText, symbol.GetJitDisasmTarget());
+            }
+        }
+
+        [TestMethod]
+        public void GetContainingTypeNameOrSelfTest()
+        {
+            Check("MyStruct", "MyStruct");
+            Check("MyClass", "MyClass");
+            Check("MyClass", "MyMethod");
+            Check("MyClass", "MyProperty");
+            Check("MyClass", "get { return p_");
+            Check("MyClass", "set { p_");
+            Check("MyClass", "this[");
+            Check("MyClass", "get { return i_");
+            Check("MyClass", "set { i_");
+
+            static void Check(string expectedName, string uniqueIdentifier)
+            {
+                var symbol = RoslynHelper.GetSymbolByUniqueIdentifier(SourceCode, uniqueIdentifier);
+                Assert.AreEqual(expectedName, symbol.GetContainingTypeNameOrSelf());
+            }
+        }
+    }
+}

--- a/Disasmo.Tests/RoslynHelper.cs
+++ b/Disasmo.Tests/RoslynHelper.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Disasmo.Tests
+{
+    public static class RoslynHelper
+    {
+        private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+
+        public static SemanticModel GetSemanticModelForSourceCode(string source)
+        {
+            const string TestProjectName = "TestProject";
+
+            var projectId = ProjectId.CreateNewId();
+            var solution = new AdhocWorkspace()
+                .CurrentSolution
+                .AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp)
+                .AddMetadataReference(projectId, CorlibReference)
+                .AddMetadataReference(projectId, SystemCoreReference);
+
+            var sourceText = SourceText.From(source);
+            var document = solution.Projects.Single().AddDocument("NewFile.cs", sourceText);
+
+            return document.GetSemanticModelAsync().Result;
+        }
+
+        public static ISymbol GetSymbolAtPosition(this SemanticModel semanticModel, int tokenPosition)
+        {
+            var syntaxTree = semanticModel.SyntaxTree.GetRoot();
+            var token = syntaxTree.FindToken(tokenPosition);
+            var symbol = semanticModel.GetDeclaredSymbol(token.Parent); //null for getters and setters
+            return symbol ?? semanticModel.GetEnclosingSymbol(tokenPosition);
+        }
+
+        public static ISymbol GetSymbolByUniqueIdentifier(string source, string symbolIdentifier)
+        {
+            var semanticModel = GetSemanticModelForSourceCode(source);
+            return semanticModel.GetSymbolAtPosition(source.IndexOf(symbolIdentifier));
+        }
+    }
+}

--- a/Disasmo.sln
+++ b/Disasmo.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 16.0.28516.95
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Disasmo.Vsix", "src\Vsix\Disasmo.Vsix.csproj", "{3334577B-6E6F-4AF2-BDD3-FE03D697CCC5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsolePlayground", "src\ConsolePlayground\ConsolePlayground.csproj", "{D890274C-FF75-43B5-9FDD-C41E6D784639}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsolePlayground", "src\ConsolePlayground\ConsolePlayground.csproj", "{D890274C-FF75-43B5-9FDD-C41E6D784639}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Disasmo.Tests", "Disasmo.Tests\Disasmo.Tests.csproj", "{7A7EE0E0-D911-428C-9080-80E59B2FA684}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{D890274C-FF75-43B5-9FDD-C41E6D784639}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D890274C-FF75-43B5-9FDD-C41E6D784639}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D890274C-FF75-43B5-9FDD-C41E6D784639}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A7EE0E0-D911-428C-9080-80E59B2FA684}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A7EE0E0-D911-428C-9080-80E59B2FA684}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A7EE0E0-D911-428C-9080-80E59B2FA684}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A7EE0E0-D911-428C-9080-80E59B2FA684}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Vsix/Analyzers/Base/BaseSuggestedAction.cs
+++ b/src/Vsix/Analyzers/Base/BaseSuggestedAction.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,10 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.Language.Intellisense;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
-using Point = System.Windows.Point;
-using Size = System.Windows.Size;
 using Task = System.Threading.Tasks.Task;
 
 namespace Disasmo

--- a/src/Vsix/Analyzers/DisasmMethodOrClassAction.cs
+++ b/src/Vsix/Analyzers/DisasmMethodOrClassAction.cs
@@ -1,16 +1,17 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Disasmo.Analyzers;
 using Disasmo.Properties;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Document = Microsoft.CodeAnalysis.Document;
 
 namespace Disasmo
 {
-
     internal class DisasmMethodOrClassAction : BaseSuggestedAction
     {
-        public DisasmMethodOrClassAction(CommonSuggestedActionsSource actionsSource) : base(actionsSource) {}
+        public DisasmMethodOrClassAction(CommonSuggestedActionsSource actionsSource) : base(actionsSource) { }
 
         public override async void Invoke(CancellationToken cancellationToken)
         {
@@ -22,25 +23,8 @@ namespace Disasmo
         {
             try
             {
-                SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken);
-
-                var syntaxTree = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken);
-                var token = syntaxTree.FindToken(tokenPosition);
-
-                if (Settings.Default?.AllowDisasmInvocations == true &&
-                    token.Parent?.Parent?.Parent is InvocationExpressionSyntax i)
-                    return semanticModel.GetSymbolInfo(i, cancellationToken).Symbol;
-
-                if (token.Parent is MethodDeclarationSyntax m)
-                    return semanticModel.GetDeclaredSymbol(m, cancellationToken);
-
-                if (token.Parent is ClassDeclarationSyntax c)
-                    return semanticModel.GetDeclaredSymbol(c, cancellationToken);
-
-                if (token.Parent is StructDeclarationSyntax s)
-                    return semanticModel.GetDeclaredSymbol(s, cancellationToken);
-
-                return null;
+                var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+                return await GetSymbolAsync(semanticModel, tokenPosition, cancellationToken);
             }
             catch
             {
@@ -48,21 +32,34 @@ namespace Disasmo
             }
         }
 
-        public override string DisplayText
+        internal static async Task<ISymbol> GetSymbolAsync(SemanticModel semanticModel, int tokenPosition, CancellationToken cancellationToken)
         {
-            get
+            var syntaxTree = await semanticModel.SyntaxTree.GetRootAsync(cancellationToken);
+            var token = syntaxTree.FindToken(tokenPosition);
+
+            SyntaxNode node = null;
+            switch (token.Parent.Kind())
             {
-                try
-                {
-                    if (_symbol is IMethodSymbol)
-                        return $"Disasm '{_symbol?.Name}' method";
-                    return $"Disasm '{_symbol?.Name}' class";
-                }
-                catch
-                {
-                    return "-";
-                }
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.PropertyDeclaration:
+                case SyntaxKind.GetAccessorDeclaration:
+                case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.IndexerDeclaration:
+                case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.StructDeclaration:
+                    node = token.Parent;
+                    break;
+                case SyntaxKind.IdentifierName:
+                    if (Settings.Default?.AllowDisasmInvocations == true)
+                    {
+                        node = token.Parent?.Parent?.Parent as InvocationExpressionSyntax;
+                    }
+                    break;
             }
+
+            return node != null ? semanticModel.GetDeclaredSymbol(node, cancellationToken) : null;
         }
+
+        public override string DisplayText => _symbol.GetDisasmSuggestedActionDisplayText();
     }
 }

--- a/src/Vsix/Analyzers/ISymbolExtensions.cs
+++ b/src/Vsix/Analyzers/ISymbolExtensions.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Disasmo.Analyzers
+{
+    public static class ISymbolExtensions
+    {
+        public static string GetJitDisasmTarget(this ISymbol symbol)
+        {
+            // see https://github.com/dotnet/coreclr/blob/master/Documentation/building/viewing-jit-dumps.md#specifying-method-names
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Method:
+                    return symbol.ContainingType.Name + "::" + symbol.Name;
+                case SymbolKind.Property:
+                    var propertySymbol = (IPropertySymbol)symbol;
+                    var getMethod = propertySymbol.GetMethod;
+                    var setMethod = propertySymbol.SetMethod;
+                    if (getMethod != null && setMethod != null)
+                    {
+                        return $"{GetJitDisasmTarget(getMethod)} {GetJitDisasmTarget(setMethod)}";
+                    }
+                    else
+                    {
+                        if (getMethod != null) return GetJitDisasmTarget(getMethod);
+                        else return GetJitDisasmTarget(setMethod);
+                    }
+                default:
+                    return symbol.Name + "::*";
+            }
+        }
+
+        public static string GetDisasmSuggestedActionDisplayText(this ISymbol symbol)
+        {
+            try
+            {
+                string name = symbol?.Name;
+                string symbolType;
+                switch (symbol.Kind)
+                {
+                    case SymbolKind.Method:
+                        var methodSymbol = (IMethodSymbol)symbol;
+                        switch (methodSymbol.MethodKind)
+                        {
+                            case MethodKind.PropertyGet:
+                                symbolType = $"{(IsIndexer() ? "indexer" : "property")} getter";
+                                name = methodSymbol.AssociatedSymbol.Name;
+                                break;
+                            case MethodKind.PropertySet:
+                                symbolType = $"{(IsIndexer() ? "indexer" : "property")} setter";
+                                name = methodSymbol.AssociatedSymbol.Name;
+                                break;
+                            default:
+                                symbolType = "method";
+                                break;
+                        }
+
+                        bool IsIndexer() => (methodSymbol.AssociatedSymbol as IPropertySymbol)?.IsIndexer ?? false;
+                        break;
+                    case SymbolKind.NamedType:
+                        symbolType = ((INamedTypeSymbol)symbol).IsValueType ? "struct" : "class";
+                        break;
+                    case SymbolKind.Property:
+                        symbolType = ((IPropertySymbol)symbol).IsIndexer ? "indexer" : "property";
+                        break;
+                    default:
+                        symbolType = string.Empty;
+                        break;
+                }
+                return $"Disasm '{name}' {symbolType}";
+            }
+            catch
+            {
+                return "-";
+            }
+        }
+
+        public static string GetContainingTypeNameOrSelf(this ISymbol symbol)
+        {
+            return symbol.Kind == SymbolKind.NamedType ? symbol.Name : symbol.ContainingType.Name;
+        }
+    }
+}

--- a/src/Vsix/Disasmo.Vsix.csproj
+++ b/src/Vsix/Disasmo.Vsix.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Analyzers\Base\CommonSuggestedActionsSourceProvider.cs" />
     <Compile Include="Analyzers\DisasmMethodOrClassAction.cs" />
     <Compile Include="Analyzers\Base\CommonSuggestedActionsSource.cs" />
+    <Compile Include="Analyzers\ISymbolExtensions.cs" />
     <Compile Include="Analyzers\ObjectLayoutSuggestedAction.cs" />
     <EmbeddedResource Include="Resources\LauncherTemplate\Main.cs" />
     <Compile Include="Utils\ComPlusDisassemblyPrettifier.cs" />

--- a/src/Vsix/Properties/AssemblyInfo.cs
+++ b/src/Vsix/Properties/AssemblyInfo.cs
@@ -31,3 +31,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("Disasmo.Tests")]


### PR DESCRIPTION
Properties and indexers now can be disasmed.
![image](https://user-images.githubusercontent.com/11704036/75098471-ff120000-55b6-11ea-91ba-055277ea8fd7.png)
![image](https://user-images.githubusercontent.com/11704036/75098484-1b15a180-55b7-11ea-8926-6b95a9f6502d.png)
![image](https://user-images.githubusercontent.com/11704036/75098490-2ec10800-55b7-11ea-87c8-68f7f68d8879.png)
and so on..
Following suggestion display texts are now available:
- Disasm 'MyClass' class
- Disasm 'MyStruct' struct
- Disasm 'MyMethod' method
- Disasm 'MyProperty' property
- Disasm 'MyProperty' property getter
- Disasm 'MyProperty' property setter
- Disasm 'this[]' indexer
- Disasm 'this[]' indexer getter
- Disasm 'this[]' indexer setter

I have also added unit tests for Roslyn based stuff which I've came across.

Hopefully you will like it!