### PR TITLE
Add handling for nested types

### DIFF
--- a/src/Loader/DisasmoLoader.cs
+++ b/src/Loader/DisasmoLoader.cs
@@ -26,7 +26,11 @@ public class DisasmoLoader
         Assembly asm = alc.LoadFromAssemblyPath(Path.Combine(Environment.CurrentDirectory, assemblyName));
         foreach (Type type in asm.GetTypes())
         {
-            if (string.IsNullOrWhiteSpace(typeName) || type.FullName.Contains(typeName))
+            // We replace pluses with dots because 'typeName' is a C#'y name of the type
+            // Unfortunately, Roslyn doesn't have a display option to output the runtime name of the type
+            // And we do not want to complicate things by formatting the type's name ourselves
+            // This is the easiest solution to that problem
+            if (string.IsNullOrWhiteSpace(typeName) || type.FullName.Replace('+', '.').Contains(typeName))
             {
                 foreach (var method in type.GetMethods((BindingFlags)60))
                 {

--- a/src/Vsix/Utils/IdeUtils.cs
+++ b/src/Vsix/Utils/IdeUtils.cs
@@ -114,13 +114,13 @@ namespace Disasmo
         {
             try
             {
-                await DisasmoPackage.Current.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
                 if (DisasmoPackage.Current == null)
                 {
                     MessageBox.Show("DisasmoPackage is loading... please try again later.");
                     return null;
                 }
+
+                await DisasmoPackage.Current.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
                 await DisasmoPackage.Current.ShowToolWindowAsync(typeof(DisasmWindow), 0, create: true, cancellationToken: cancellationToken);
                 await DisasmoPackage.Current.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);


### PR DESCRIPTION
Right now, disassembling methods for nested types shows a blank page because the type name is passed to the loader in a C# format, with dots as separators, while the runtime's formatter uses pluses.

This PR addresses that with a simple workaround in the loader that C#-ies runtime type names. It also adds a comment explaining the motivation behind that decision instead of, for example, passing the properly formatted type string to the loader.

This PR also fixes an issue where the null check was inserted too late and the member access before it would have always failed with a null-ref exception. As far as I can tell, this only impacts local debugging scenarios.

I noticed that the analyzers in the solution produce a lot of `VSTHRD010` warnings. Can they be safely suppressed?
If not, I have some free time these holidays and can work on addressing them, as well as #17 (on which I just need guidance on the best approach).