### PR TITLE
Provide error in case of broken VS state

### DIFF
--- a/src/Vsix/ViewModels/MainViewModel.cs
+++ b/src/Vsix/ViewModels/MainViewModel.cs
@@ -548,6 +548,12 @@ namespace Disasmo
 
                 // Find Release-x64 configuration:
                 Project currentProject = dte.GetActiveProject();
+                if (currentProject is null)
+                {
+                    Output = "There no active project. Please re-open solution.";
+                    return;
+                }
+
                 IProjectProperties projectProperties = await IdeUtils.GetProjectProperties(GetUnconfiguredProject(currentProject), "Release");
 
                 ThrowIfCanceled();


### PR DESCRIPTION
I change TargetFramework to TargetFrameworks and VS as usually produce warnings For some reasons after that Active project become null. This is just to inform user that Visual Studio is broken. Maybe we can display yellow status bar like others, but I did ont know service which do that reporting.