### PR TITLE
Add support for generic types and methods

### DIFF
--- a/Disasmo/Resources/DisasmoLoader4.cs_template
+++ b/Disasmo/Resources/DisasmoLoader4.cs_template
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -28,11 +31,15 @@ public class DisasmoLoader
 
         var alc = new AssemblyLoadContext("DisasmoALC", unloadable == "True");
         Assembly asm = alc.LoadFromAssemblyPath(Path.Combine(Environment.CurrentDirectory, assemblyName));
+        var generics = ParseGenerics(args[4], alc);
         Type fastType = asm.GetType(typeName);
         if (fastType != null)
         {
-            PrecompileMethods(fastType, methodName);
-            PrecompileProperties(fastType, methodName);
+            foreach (var instance in MakeGenericInstances(fastType, generics))
+            {
+                PrecompileMethods(instance, methodName, generics);
+                PrecompileProperties(instance, methodName, generics);
+            }
             return;
         }
 
@@ -44,47 +51,47 @@ public class DisasmoLoader
             // This is the easiest solution to that problem
             if (type.FullName?.Replace('+', '.').Contains(typeName) == true)
             {
-                PrecompileMethods(type, methodName);
-                PrecompileProperties(type, methodName);
+                foreach (var instance in MakeGenericInstances(type, generics))
+                {
+                    PrecompileMethods(instance, methodName, generics);
+                    PrecompileProperties(instance, methodName, generics);
+                }
             }
         }
     }
 
-    private static void PrecompileProperties(Type type, string propertyName)
+    private static void PrecompileProperties(Type type, string propertyName, Dictionary<string, List<Type>> generics)
     {
         foreach (PropertyInfo propInfo in type.GetProperties((BindingFlags)60))
         {
             if (propInfo.Name == "*" || propInfo.Name == propertyName)
             {
                 if (propInfo.GetMethod != null)
-                    RuntimeHelpers.PrepareMethod(propInfo.GetMethod.MethodHandle);
+                    Prepare(propInfo.GetMethod, generics);
                 if (propInfo.SetMethod != null)
-                    RuntimeHelpers.PrepareMethod(propInfo.SetMethod.MethodHandle);
+                    Prepare(propInfo.SetMethod, generics);
             }
         }
     }
 
-    private static void PrecompileMethods(Type type, string methodName)
+    private static void PrecompileMethods(Type type, string methodName, Dictionary<string, List<Type>> generics)
     {
         foreach (MethodBase method in
                  type.GetMethods((BindingFlags)60).Concat(
                      type.GetConstructors((BindingFlags)60).Select(c => (MethodBase)c)))
         {
-            if (method.IsGenericMethod)
-                continue;
-
             try
             {
                 if (method.DeclaringType == type || method.DeclaringType == null)
                 {
                     if (methodName == "*" || method.Name == methodName)
                     {
-                        RuntimeHelpers.PrepareMethod(method.MethodHandle);
+                        Prepare(method, generics);
                     }
                     else if (method.Name.Contains(">g__" + methodName))
                     {
                         // Special case for local functions
-                        RuntimeHelpers.PrepareMethod(method.MethodHandle);
+                        Prepare(method, generics);
                     }
                 }
             }
@@ -92,5 +99,266 @@ public class DisasmoLoader
             {
             }
         }
+    }
+
+    private static void Prepare(MethodBase method, Dictionary<string, List<Type>> generics)
+    {
+        if (method is MethodInfo)
+        {
+            foreach (var instance in MakeGenericInstances((MethodInfo)method, generics))
+            {
+                try
+                {
+                    RuntimeHelpers.PrepareMethod(instance.MethodHandle);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                }
+            }
+        }
+        else
+        {
+            try
+            {
+                RuntimeHelpers.PrepareMethod(method.MethodHandle);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+    }
+
+    private static Dictionary<string, List<Type>> ParseGenerics(ReadOnlySpan<char> data, AssemblyLoadContext alc)
+    {
+        var result = new Dictionary<string, List<Type>>();
+        while (!data.IsEmpty)
+        {
+            int eq = data.IndexOf('=');
+            string name = data[..eq].ToString();
+            data = data[(eq + 1)..];
+            Type type = ParseType(ref data, alc);
+
+            if (type != null)
+            {
+                if (!result.ContainsKey(name))
+                {
+                    result[name] = new List<Type>() { type };
+                }
+                else
+                {
+                    result[name].Add(type);
+                }
+            }
+
+            data = data[1..];
+        }
+
+        return result;
+    }
+
+    private static Type ParseType(ref ReadOnlySpan<char> data, AssemblyLoadContext alc)
+    {
+        int nameEnd = data.IndexOfAny("[],;");
+        string name = data[..nameEnd].ToString();
+        Type type = FindType(name, alc);
+        data = data[nameEnd..];
+
+        if (data[0] == ']' || data[0] == ',' || data[0] == ';')
+        {
+            return type;
+        }
+
+        int argEnd = data.IndexOf(']');
+
+        if (argEnd == 1)
+        {
+            data = data[2..];
+            return type?.MakeArrayType();
+        }
+
+        if (argEnd == 2 && data[1] == '*')
+        {
+            data = data[3..];
+            return type?.MakePointerType();
+        }
+
+        if (int.TryParse(data[1..argEnd], NumberStyles.Integer, CultureInfo.InvariantCulture, out int rank))
+        {
+            data = data[(argEnd + 1)..];
+            return type?.MakeArrayType(rank);
+        }
+
+        List<Type> args = new List<Type>();
+
+        while (data[0] != ']')
+        {
+            data = data[1..];
+            args.Add(ParseType(ref data, alc));
+        }
+
+        data = data[1..];
+        if (args.Contains(null))
+        {
+            return null;
+        }
+        return type?.MakeGenericType(args.ToArray());
+    }
+
+    private static Type FindType(string name, AssemblyLoadContext alc)
+    {
+        foreach (Assembly assembly in alc.Assemblies)
+        {
+            Type type = assembly.GetType(name);
+            if (type != null)
+            {
+                return type;
+            }
+        }
+
+        foreach (Assembly assembly in AssemblyLoadContext.Default.Assemblies)
+        {
+            Type type = assembly.GetType(name);
+            if (type != null)
+            {
+                return type;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<Type> MakeGenericInstances(Type type, Dictionary<string, List<Type>> arguments)
+    {
+        if (!type.IsGenericType)
+        {
+            yield return type;
+            yield break;
+        }
+
+        var hasVariant = false;
+        type = type.GetGenericTypeDefinition();
+        var variants = MakeGenericVariants(type.GetGenericArguments(), arguments);
+
+        foreach (var variant in variants)
+        {
+            Type instance = null;
+            try
+            {
+                instance = type.MakeGenericType(variant);
+            }
+            catch (ArgumentException ex)
+            {
+                // probably fails some constraint
+            }
+
+            if (instance != null)
+            {
+                hasVariant = true;
+                yield return instance;
+            }
+        }
+
+        if (!hasVariant)
+        {
+            Console.WriteLine("Unable to create instance for " + type + ". Check that the provided arguments fullfill the constraints.");
+        }
+    }
+
+
+    private static IEnumerable<MethodBase> MakeGenericInstances(MethodBase method, Dictionary<string, List<Type>> arguments)
+    {
+        if (method is not MethodInfo info || !method.IsGenericMethod)
+        {
+            yield return method;
+            yield break;
+        }
+
+        var hasVariant = false;
+        info = info.GetGenericMethodDefinition();
+        var variants = MakeGenericVariants(info.GetGenericArguments(), arguments);
+
+        foreach (var variant in variants)
+        {
+            MethodInfo instance = null;
+            try
+            {
+                instance = info.MakeGenericMethod(variant);
+            }
+            catch (ArgumentException ex)
+            {
+                // probably fails some constraint
+            }
+
+            if (instance != null)
+            {
+                hasVariant = true;
+                yield return instance;
+            }
+        }
+
+        if (!hasVariant)
+        {
+            Console.WriteLine("Unable to create instance for " + method + ". Check that the provided arguments fullfill the constraints.");
+        }
+    }
+
+    private static List<Type[]> MakeGenericVariants(Type[] parameters, Dictionary<string, List<Type>> arguments)
+    {
+        var results = new List<Type[]>() { new Type[parameters.Length] };
+
+        arguments.TryGetValue("*", out var applyAlways);
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            arguments.TryGetValue(parameters[i].Name, out var applyArgument);
+
+            var count = (applyAlways?.Count ?? 0) + (applyArgument?.Count ?? 0);
+
+            if (count == 0)
+            {
+                Console.WriteLine("No arguments to apply for generic parameter " + parameters[i].Name);
+                results.Clear(); // cross product will be empty, don't return to print this warning potentially multiple times
+            }
+            else if (count == 1)
+            {
+                var argument = applyAlways?[0] ?? applyArgument?[0];
+
+                foreach (var variant in results)
+                {
+                    variant[i] = argument;
+                }
+            }
+            else
+            {
+                var preResults = results;
+                results = new List<Type[]>();
+
+                foreach (var variant in preResults)
+                {
+                    if (applyAlways != null)
+                    {
+                        foreach (var argument in applyAlways)
+                        {
+                            var copy = variant.ToArray();
+                            copy[i] = argument;
+                            results.Add(copy);
+                        }
+                    }
+                    if (applyArgument != null)
+                    {
+                        foreach (var argument in applyArgument)
+                        {
+                            var copy = variant.ToArray();
+                            copy[i] = argument;
+                            results.Add(copy);
+                        }
+                    }
+                }
+            }
+        }
+
+        return results;
     }
 }

--- a/Disasmo/Utils/SymbolUtils.cs
+++ b/Disasmo/Utils/SymbolUtils.cs
@@ -2,7 +2,7 @@
 
 namespace Disasmo.Utils;
 
-public class SymbolUtils
+public static class SymbolUtils
 {
     public static DisasmoSymbolInfo FromSymbol(ISymbol symbol)
     {
@@ -16,35 +16,49 @@ public class SymbolUtils
             {
                 // hack for mangled names
                 target = "*" + symbol.Name + "*";
-                hostType = symbol.ContainingType.ToString();
+                hostType = symbol.ContainingType.MetadataName;
                 methodName = "*";
             }
             else if (ms.MethodKind == MethodKind.Constructor)
             {
-                target = "*" + symbol.ContainingType.Name + ":.ctor";
-                hostType = symbol.ContainingType.ToString();
+                target = "*" + symbol.ContainingType.MetadataName + ":.ctor";
+                hostType = symbol.ContainingType.MetadataName();
                 methodName = "*";
             }
             else
             {
-                target = "*" + symbol.ContainingType.Name + ":" + symbol.Name;
-                hostType = symbol.ContainingType.ToString();
+                target = "*" + symbol.ContainingType.MetadataName + ":" + symbol.Name;
+                hostType = symbol.ContainingType.MetadataName();
                 methodName = symbol.Name;
             }
         }
         else if (symbol is IPropertySymbol prop)
         {
-            target = "*" + symbol.ContainingType.Name + ":get_" + symbol.Name + " " + "*" + symbol.ContainingType.Name + ":set_" + symbol.Name;
-            hostType = symbol.ContainingType.ToString();
+            target = "*" + symbol.ContainingType.MetadataName + ":get_" + symbol.Name + " " + "*" + symbol.ContainingType.MetadataName + ":set_" + symbol.Name;
+            hostType = symbol.ContainingType.MetadataName();
             methodName = symbol.Name;
         }
         else
         {
             // the whole class
             target = symbol.Name + ":*";
-            hostType = symbol.ToString();
+            hostType = symbol.MetadataName;
             methodName = "*";
         }
         return new DisasmoSymbolInfo(target, hostType, methodName);
+    }
+
+    private static string MetadataName(this INamedTypeSymbol type)
+    {
+        string name = "";
+        if (type.ContainingType != null)
+        {
+            name = type.ContainingType.MetadataName() + "+";
+        }
+        else if (type.ContainingNamespace != null && !type.ContainingNamespace.IsGlobalNamespace)
+        {
+            name = type.ContainingNamespace.ToString() + ".";
+        }
+        return name + type.MetadataName;
     }
 }

--- a/src/Vsix/Properties/Settings.Designer.cs
+++ b/src/Vsix/Properties/Settings.Designer.cs
@@ -252,5 +252,17 @@ namespace Disasmo.Properties {
                 this["DontGuessTFM"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("*=System.Int32;*=System.Tuple`2[System.Object,System.Int32];")]
+        public string GenericArguments {
+            get {
+                return ((string)(this["GenericArguments"]));
+            }
+            set {
+                this["GenericArguments"] = value;
+            }
+        }
     }
 }

--- a/src/Vsix/Properties/Settings.settings
+++ b/src/Vsix/Properties/Settings.settings
@@ -59,5 +59,8 @@
     <Setting Name="DontGuessTFM" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="GenericArguments" Type="System.String" Scope="User">
+      <Value Profile="(Default)">*=System.Int32;*=System.Tuple`2[System.Object,System.Int32];</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/Vsix/ViewModels/MainViewModel.cs
+++ b/src/Vsix/ViewModels/MainViewModel.cs
@@ -225,7 +225,7 @@ namespace Disasmo
                     envVars["DOTNET_JitDumpFgFile"] = currentFgFile;
                 }
 
-                string command = $"\"{LoaderAppManager.DisasmoLoaderName}.dll\" \"{fileName}.dll\" \"{symbolInfo.ClassName}\" \"{symbolInfo.MethodName}\" {SettingsVm.UseUnloadableContext}";
+                string command = $"\"{LoaderAppManager.DisasmoLoaderName}.dll\" \"{fileName}.dll\" \"{symbolInfo.ClassName}\" \"{symbolInfo.MethodName}\" {SettingsVm.UseUnloadableContext} \"{string.Concat(SettingsVm.GenericArguments)}\"";
                 if (SettingsVm.RunAppMode)
                 {
                     command = $"\"{fileName}.dll\"";
@@ -533,13 +533,6 @@ namespace Disasmo
                     if (!success)
                         return;
                     clrCheckedFilesDir = dir;
-                }
-
-                if (symbol is IMethodSymbol { IsGenericMethod: true })
-                {
-                    // TODO: ask user to specify type parameters
-                    Output = "Generic methods are not supported yet.";
-                    return;
                 }
 
                 ThrowIfCanceled();

--- a/src/Vsix/ViewModels/SettingsViewModel.cs
+++ b/src/Vsix/ViewModels/SettingsViewModel.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Windows.Forms;
 using System.Windows.Input;
 using Disasmo.Properties;
@@ -38,6 +40,7 @@ namespace Disasmo
         private string _selectedCustomJit;
         private string _graphvisDot;
         private bool _fgEnable;
+        private ObservableCollection<GenericArgument> _genericArguments;
 
         public SettingsViewModel()
         {
@@ -61,6 +64,9 @@ namespace Disasmo
             UseUnloadableContext = Settings.Default.UseUnloadableContext;
             DisableLightBulb = Settings.Default.DisableLightBulb;
             DontGuessTFM = Settings.Default.DontGuessTFM;
+            GenericArguments = new ObservableCollection<GenericArgument>(
+                Settings.Default.GenericArguments.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(s => new GenericArgument(s))
+            );
             CheckUpdates();
         }
 
@@ -408,6 +414,61 @@ namespace Disasmo
             }
         }
 
+        public ObservableCollection<GenericArgument> GenericArguments
+        {
+            get => _genericArguments;
+            set
+            {
+                if (_genericArguments != null)
+                {
+                    foreach (var argument in _genericArguments)
+                        argument.PropertyChanged -= GenericArgumentsPropertyChanged;
+                    _genericArguments.CollectionChanged -= GenericArgumentsCollectionChanged;
+                }
+                Set(ref _genericArguments, value);
+                if (_genericArguments != null)
+                {
+                    _genericArguments.CollectionChanged += GenericArgumentsCollectionChanged;
+                    foreach (var argument in _genericArguments)
+                        argument.PropertyChanged += GenericArgumentsPropertyChanged;
+                }
+            }
+        }
+
+        private void GenericArgumentsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (var oldItem in e.OldItems)
+                {
+                    if (oldItem is INotifyPropertyChanged changed)
+                    {
+                        changed.PropertyChanged -= GenericArgumentsPropertyChanged;
+                    }
+                }
+            }
+
+            if (e.NewItems != null)
+            {
+                foreach (var newItem in e.NewItems)
+                {
+                    if (newItem is INotifyPropertyChanged changed)
+                    {
+                        changed.PropertyChanged += GenericArgumentsPropertyChanged;
+                    }
+                }
+            }
+
+            Settings.Default.GenericArguments = string.Concat(_genericArguments);
+            Settings.Default.Save();
+        }
+
+        private void GenericArgumentsPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            Settings.Default.GenericArguments = string.Concat(_genericArguments);
+            Settings.Default.Save();
+        }
+
         public bool UpdateIsAvailable
         {
             get => _updateIsAvailable;
@@ -464,5 +525,47 @@ namespace Disasmo
 
             return null;
         }
+    }
+
+    public class GenericArgument : INotifyPropertyChanged
+    {
+        private string _argument;
+        private string _type;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public GenericArgument(string value)
+        {
+            var parts = value.Split('=');
+            _argument = parts[0];
+            _type = parts[1];
+        }
+
+        public string Argument
+        {
+            get => _argument;
+            set => SetField(ref _argument, value);
+        }
+
+        public string Type
+        {
+            get => _type;
+            set => SetField(ref _type, value);
+        }
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        protected bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        public override string ToString() => $"{_argument}={_type};";
     }
 }

--- a/src/Vsix/Views/DisasmWindowControl.xaml
+++ b/src/Vsix/Views/DisasmWindowControl.xaml
@@ -278,6 +278,21 @@
                                  TextWrapping="Wrap"
                                  Text="{Binding IlcArgs, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
+                        <TextBlock Margin="8,16,8,0" Text="Types to use as arguments for generic parameters of types and methods. If Name is '*', that argument is tried for all parameters. Type must be the full metadata name of a type, and if the type has generic parameters itself, arguments can be specified by in square bracket after the type." />
+                        <StackPanel Margin="8,8,0,0" Orientation="Horizontal">
+                            <Button Margin="0,0,8,0" Click="OnAddGenericArgument">Add</Button>
+                            <Button Margin="0,0,8,0" Click="OnRemoveGenericArgument">Remove</Button>
+                            <Button Margin="0,0,8,0" Click="OnMoveUpGenericArgument">Up</Button>
+                            <Button Margin="0,0,8,0" Click="OnMoveDownGenericArgument">Down</Button>
+                            <Button Margin="0,0,8,0" Click="OnCopyGenericArgument">Copy</Button>
+                            <Button Margin="0,0,8,0" Click="OnPasteGenericArgument">Paste</Button>
+                        </StackPanel>
+                        <DataGrid Margin="8,8,8,8" ItemsSource="{Binding GenericArguments}" AutoGenerateColumns="False" CanUserSortColumns="False" Name="GenericArgumentGrid">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Name" Binding="{Binding Argument}"></DataGridTextColumn>
+                                <DataGridTextColumn Header="Type" Binding="{Binding Type}" Width="*"></DataGridTextColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/src/Vsix/Views/DisasmWindowControl.xaml.cs
+++ b/src/Vsix/Views/DisasmWindowControl.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Data;
 using System.Windows.Navigation;
@@ -112,6 +114,57 @@ namespace Disasmo
                 catch
                 {
                 }
+            }
+        }
+
+        private void OnAddGenericArgument(object sender, RoutedEventArgs e)
+        {
+            MainViewModel.SettingsVm.GenericArguments.Add(new GenericArgument("*=System.Int32"));
+        }
+
+        private void OnRemoveGenericArgument(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in GenericArgumentGrid.SelectedItems.Cast<GenericArgument>().ToArray())
+            {
+                MainViewModel.SettingsVm.GenericArguments.Remove(item);
+            }
+        }
+
+        private void OnMoveUpGenericArgument(object sender, RoutedEventArgs e)
+        {
+            foreach (int index in GenericArgumentGrid.SelectedItems.Cast<GenericArgument>().Select(MainViewModel.SettingsVm.GenericArguments.IndexOf).OrderBy(v => v))
+            {
+                if (index > 0)
+                {
+                    MainViewModel.SettingsVm.GenericArguments.Move(index, index - 1);
+                }
+            }
+        }
+
+        private void OnMoveDownGenericArgument(object sender, RoutedEventArgs e)
+        {
+            foreach (int index in GenericArgumentGrid.SelectedItems.Cast<GenericArgument>().Select(MainViewModel.SettingsVm.GenericArguments.IndexOf).OrderByDescending(v => v))
+            {
+                if (index >= 0 && index < MainViewModel.SettingsVm.GenericArguments.Count - 1)
+                {
+                    MainViewModel.SettingsVm.GenericArguments.Move(index, index + 1);
+                }
+            }
+        }
+
+        private void OnCopyGenericArgument(object sender, RoutedEventArgs e)
+        {
+            Clipboard.SetText(string.Join("\n", MainViewModel.SettingsVm.GenericArguments));
+        }
+
+        private void OnPasteGenericArgument(object sender, RoutedEventArgs e)
+        {
+            string text = Clipboard.GetText();
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                MainViewModel.SettingsVm.GenericArguments = new ObservableCollection<GenericArgument>(
+                    text.Split(new[] { ';', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).Select(s => new GenericArgument(s))
+                );
             }
         }
     }

--- a/src/Vsix/app.config
+++ b/src/Vsix/app.config
@@ -64,6 +64,9 @@
             <setting name="DontGuessTFM" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="GenericArguments" serializeAs="String">
+                <value>*=System.Int32;*=System.Tuple`2[System.Object,System.Int32];</value>
+            </setting>
         </Disasmo.Properties.Settings>
     </userSettings>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>


### PR DESCRIPTION
Adds a setting to provide types to use for generic arguments.

Example:

```csharp
static T[] NewArray<T>()
{
	return new T[5];
}
```

produces the output

```asm
; Assembly listing for method Program2:NewArray[System.__Canon]():<unnamed>
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; Final local variable assignments
;
;  V00 TypeCtx      [V00,T00] (  5,  4.25)    long  ->  rcx         single-def
;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T01] (  3,  3   )    long  ->  rdx         "spilling Runtime Lookup tree"
;  V03 cse0         [V03,T02] (  3,  2.25)    long  ->  rdx         "CSE - aggressive"
;
; Lcl frame size = 40

G_M13538_IG01:              ;; offset=0000H
       4883EC28             sub      rsp, 40
       48894C2420           mov      qword ptr [rsp+20H], rcx
						;; size=9 bbWeight=1    PerfScore 1.25
G_M13538_IG02:              ;; offset=0009H
       488B5138             mov      rdx, qword ptr [rcx+38H]
       488B5210             mov      rdx, qword ptr [rdx+10H]
       4885D2               test     rdx, rdx
       7402                 je       SHORT G_M13538_IG04
						;; size=13 bbWeight=1    PerfScore 5.25
G_M13538_IG03:              ;; offset=0016H
       EB12                 jmp      SHORT G_M13538_IG05
						;; size=2 bbWeight=0.25 PerfScore 0.50
G_M13538_IG04:              ;; offset=0018H
       48BA905DC4D6F77F0000 mov      rdx, 0x7FF7D6C45D90      ; global ptr
       E899F9505F           call     CORINFO_HELP_RUNTIMEHANDLE_METHOD
       488BD0               mov      rdx, rax
						;; size=18 bbWeight=0.25 PerfScore 0.38
G_M13538_IG05:              ;; offset=002AH
       488BCA               mov      rcx, rdx
       BA05000000           mov      edx, 5
       E809F7875F           call     CORINFO_HELP_NEWARR_1_OBJ
       90                   nop      
						;; size=14 bbWeight=1    PerfScore 1.75
G_M13538_IG06:              ;; offset=0038H
       4883C428             add      rsp, 40
       C3                   ret      
						;; size=5 bbWeight=1    PerfScore 1.25

; Total bytes of code 61, prolog size 9, PerfScore 16.48, instruction count 16, allocated bytes for code 61 (MethodHash=f226cb1d) for method Program2:NewArray[System.__Canon]():<unnamed>
; ============================================================

; Assembly listing for method Program2:NewArray[int]():<unnamed>
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; Final local variable assignments
;
;  V00 OutArgs      [V00    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"
;
; Lcl frame size = 40

G_M25943_IG01:              ;; offset=0000H
       4883EC28             sub      rsp, 40
						;; size=4 bbWeight=1    PerfScore 0.25
G_M25943_IG02:              ;; offset=0004H
       48B978D05FD6F77F0000 mov      rcx, 0x7FF7D65FD078      ; <unnamed>
       BA05000000           mov      edx, 5
       E868F6875F           call     CORINFO_HELP_NEWARR_1_VC
       90                   nop      
						;; size=21 bbWeight=1    PerfScore 1.75
G_M25943_IG03:              ;; offset=0019H
       4883C428             add      rsp, 40
       C3                   ret      
						;; size=5 bbWeight=1    PerfScore 1.25

; Total bytes of code 30, prolog size 4, PerfScore 6.25, instruction count 7, allocated bytes for code 30 (MethodHash=e37a9aa8) for method Program2:NewArray[int]():<unnamed>
; ============================================================
```

The default setting is to try `int` and `Tuple<object, int>` for all arguments, because common value type and some reference type. Exact reference type doesn't matter anyways and this way it demonstrates the syntax for specifying generic arguments.
For completeness, I added a way to specify pointer and array types, but I don't think there is a way for them to matter, so they are not documented in the UI.