### PR TITLE
Stop defining `DISASMO` and define `BuildingInsideDisasmo=true` MSBuild property instead.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# 5.9.3
+
+* Stop defining `DISASMO` symbol (replaced it with `BuildingInsideDisasmo` MSBuild property; you can achieve the existing behavior by writing `<DefineConstants Condition="$(BuildingInsideDisasmo) == true">$(DefineConstants);DISASMO</DefineConstants>`)
+
 # 5.9.2
 
 * Hot-fix for NativeAOT to avoid overwriting `DirectoryBuildPropsPath` (replaced it with `CustomBeforeDirectoryBuildProps`)

--- a/src/Vsix/ViewModels/MainViewModel.cs
+++ b/src/Vsix/ViewModels/MainViewModel.cs
@@ -395,7 +395,7 @@ namespace Disasmo
                     string dotnetPublishArgs =
                         $"publish {tfmPart} -r win-{SettingsViewModel.Arch} -c Release" +
                         $" /p:PublishAot=true /p:CustomBeforeDirectoryBuildProps=\"{tmpProps}\"" +
-                        $" /p:DefineConstants=DISASMO /p:WarningLevel=0 /p:TreatWarningsAsErrors=false -v:q";
+                        $" /p:BuildingInsideDisasmo=true /p:WarningLevel=0 /p:TreatWarningsAsErrors=false -v:q";
 
                     var publishResult = await ProcessUtils.RunProcess("dotnet", dotnetPublishArgs, null, Path.GetDirectoryName(_currentProjectPath), cancellationToken: UserCt);
 
@@ -769,7 +769,7 @@ namespace Disasmo
                     LoadingStatus = $"dotnet publish -r win-{SettingsViewModel.Arch} -c Release -o ...";
 
                     string dotnetPublishArgs =
-                        $"publish {tfmPart} -r win-{SettingsViewModel.Arch} -c Release -o {DisasmoOutDir} --self-contained true /p:PublishTrimmed=false /p:PublishSingleFile=false /p:DefineConstants=DISASMO /p:WarningLevel=0 /p:TreatWarningsAsErrors=false -v:q";
+                        $"publish {tfmPart} -r win-{SettingsViewModel.Arch} -c Release -o {DisasmoOutDir} --self-contained true /p:PublishTrimmed=false /p:PublishSingleFile=false /p:BuildingInsideDisasmo=true /p:WarningLevel=0 /p:TreatWarningsAsErrors=false -v:q";
 
                     publishResult = await ProcessUtils.RunProcess("dotnet", dotnetPublishArgs, null, currentProjectDirPath, cancellationToken: UserCt);
                 }
@@ -788,7 +788,7 @@ namespace Disasmo
                                              "/p:RuntimeIdentifier=\"\" " +
                                              "/p:RuntimeIdentifiers=\"\" " +
                                              "/p:WarningLevel=0 " +
-                                             "/p:DefineConstants=DISASMO " +
+                                             "/p:BuildingInsideDisasmo=true " +
                                              $"/p:TreatWarningsAsErrors=false \"{_currentProjectPath}\"";
 
                     Dictionary<string, string> fasterBuildEnvVars = new Dictionary<string, string>


### PR DESCRIPTION
Fixes #52.