### PR TITLE
Fix global namespace handling

### DIFF
--- a/Disasmo/Utils/SymbolUtils.cs
+++ b/Disasmo/Utils/SymbolUtils.cs
@@ -16,8 +16,8 @@ public static class SymbolUtils
         // match all for nested types
         if (containingType.ContainingType is { })
             prefix = "*";
-        else if (containingType.ContainingNamespace is { } containingNamespace)
-            prefix = containingNamespace.Name + ".";
+        else if (containingType.ContainingNamespace?.Name is { Length: > 0 } containingNamespace)
+            prefix = containingNamespace + ".";
 
         prefix += containingType.Name;
 


### PR DESCRIPTION
This was broken by #53: types in the global namespace (without any namespace declaration in C#) no longer work properly.

This PR addresses that.