### PR TITLE
Improved support for multiple projects and multiple target frameworks

### DIFF
--- a/Disasmo/Utils/SymbolUtils.cs
+++ b/Disasmo/Utils/SymbolUtils.cs
@@ -17,8 +17,15 @@ public static class SymbolUtils
         if (containingType.ContainingType is { })
             prefix = "*";
 
-        else if (containingType.ContainingNamespace?.Name is { Length: > 0 } containingNamespace)
-            prefix = containingNamespace + ".";
+        else
+        {
+            INamespaceSymbol ns = containingType.ContainingNamespace;
+            while (ns?.Name is { Length: > 0 } containingNamespace)
+            {
+                prefix = containingNamespace + "." + prefix;
+                ns = ns.ContainingNamespace;
+            }
+        }
 
         prefix += containingType.MetadataName;
 

--- a/src/Vsix/Analyzers/DisasmMethodOrClassAction.cs
+++ b/src/Vsix/Analyzers/DisasmMethodOrClassAction.cs
@@ -22,7 +22,7 @@ internal class DisasmMethodOrClassAction : BaseSuggestedAction
                 var window = await IdeUtils.ShowWindowAsync<DisasmWindow>(true, cancellationToken);
                 if (window?.ViewModel is {} viewModel)
                 {
-                    viewModel.RunOperationAsync(await GetSymbol(LastDocument, LastTokenPos, cancellationToken));
+                    viewModel.RunOperationAsync(await GetSymbol(LastDocument, LastTokenPos, cancellationToken), LastDocument.Project);
                 }
             }
         }

--- a/src/Vsix/Disasmo.Vsix.csproj
+++ b/src/Vsix/Disasmo.Vsix.csproj
@@ -62,6 +62,7 @@
       <DependentUpon>DisasmWindowControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Utils\IdeUtils.cs" />
+    <Compile Include="Utils\TfmVersion.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DisasmoPackage.cs" />

--- a/src/Vsix/DisasmoPackage.cs
+++ b/src/Vsix/DisasmoPackage.cs
@@ -171,7 +171,7 @@ public class DisasmoCommandHandler : ICommandHandler<DisasmoCommandArgs>
                         var window = await IdeUtils.ShowWindowAsync<DisasmWindow>(true, default);
                         if (window?.ViewModel is {} viewModel)
                         {
-                            viewModel.RunOperationAsync(symbol);
+                            viewModel.RunOperationAsync(symbol, document.Project);
                         }
                     }
                     catch (Exception exc)

--- a/src/Vsix/Utils/IdeUtils.cs
+++ b/src/Vsix/Utils/IdeUtils.cs
@@ -18,8 +18,20 @@ public static class IdeUtils
 {
     public static DTE DTE() => Package.GetGlobalService(typeof(SDTE)) as DTE;
 
-    public static Project GetActiveProject(this DTE dte)
+    public static Project GetActiveProject(this DTE dte, string filePath)
     {
+        // find project by full name
+        if (dte.Solution != null)
+        {
+            foreach (var projectObject in dte.Solution.Projects)
+            {
+                if (projectObject is Project project && project.FullName == filePath)
+                {
+                    return project;
+                }
+            }
+        }
+
         var activeSolutionProjects = dte.ActiveSolutionProjects as Array;
         if (activeSolutionProjects != null && activeSolutionProjects.Length > 0)
             return activeSolutionProjects.GetValue(0) as Project;

--- a/src/Vsix/Utils/TfmVersion.cs
+++ b/src/Vsix/Utils/TfmVersion.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Disasmo;
+
+public class TfmVersion : IComparable<TfmVersion>
+{
+    private static readonly Regex tfmRegex = new Regex(
+        @"^(?<moniker>[a-z]+)(?<major>\d+)(?:\.(?<minor>\d+))(?:\.(?<patch>\d+))?|(?<major>\d)(?<minor>\d)?(?<patch>\d+)?",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    public string Moniker { get; set; }
+    public int? Major { get; set; }
+    public int? Minor { get; set; }
+    public int? Patch { get; set; }
+
+    public int CompareTo(TfmVersion other)
+    {
+        if (other == null)
+            return 1;
+
+        var majorCmp = Nullable.Compare(Major, other.Major);
+        if (majorCmp != 0)
+            return majorCmp;
+
+        var minorCmp = Nullable.Compare(Minor, other.Minor);
+        if (minorCmp != 0)
+            return minorCmp;
+
+        return Nullable.Compare(Patch, other.Patch);
+    }
+
+    public override string ToString()
+    {
+        return $"{Moniker} {Major}.{Minor}.{Patch}";
+    }
+
+    public static TfmVersion Parse(string tfm)
+    {
+        var match = tfmRegex.Match(tfm);
+        if (!match.Success)
+            return null;
+
+        var moniker = match.Groups["moniker"].Value;
+        var major = match.Groups["major"].Success ? int.Parse(match.Groups["major"].Value) : (int?) null;
+        var minor = match.Groups["minor"].Success ? int.Parse(match.Groups["minor"].Value) : (int?) null;
+        var patch = match.Groups["patch"].Success ? int.Parse(match.Groups["patch"].Value) : (int?) null;
+
+        return new TfmVersion
+        {
+            Moniker = moniker,
+            Major = major,
+            Minor = minor,
+            Patch = patch,
+        };
+    }
+}


### PR DESCRIPTION
1) Fix multiple namespace handling, addition to #53
2) Determine the active project based on the selected symbol
3) Use the project configuration corresponding to the target framework, fix for #45