### PR TITLE
Update executable path for ilc.exe

### DIFF
--- a/src/Vsix/ViewModels/MainViewModel.cs
+++ b/src/Vsix/ViewModels/MainViewModel.cs
@@ -313,7 +313,7 @@ namespace Disasmo
                         return;
 
                     command = "";
-                    executable = Path.Combine(clrReleaseFolder, "ilc", "ilc.exe");
+                    executable = Path.Combine(clrReleaseFolder, "ilc-published", "ilc.exe");
 
                     command += $" \"{fileName}.dll\" ";
 

--- a/src/Vsix/ViewModels/MainViewModel.cs
+++ b/src/Vsix/ViewModels/MainViewModel.cs
@@ -602,7 +602,7 @@ namespace Disasmo
         {
             var arch = SettingsViewModel.Arch;
             var releaseFolder = Path.Combine(SettingsVm.PathToLocalCoreClr, "artifacts", "bin", "coreclr", $"windows.{arch}.Checked");
-            if (!Directory.Exists(releaseFolder) || !Directory.Exists(Path.Combine(releaseFolder, "aotsdk")) || !Directory.Exists(Path.Combine(releaseFolder, "ilc")))
+            if (!Directory.Exists(releaseFolder) || !Directory.Exists(Path.Combine(releaseFolder, "aotsdk")) || !Directory.Exists(Path.Combine(releaseFolder, "ilc-published")))
             {
                 Output = $"Path to a local dotnet/runtime repository is either not set or it's not correctly built for {arch} arch yet for NativeAOT" +
                          "\nPlease clone it and build it using the following steps.:\n\n" +


### PR DESCRIPTION
The previous one was framework dependant and required non public dotnet previews